### PR TITLE
Feature/recipe image upload

### DIFF
--- a/src/components/CreateRecipe.js
+++ b/src/components/CreateRecipe.js
@@ -93,7 +93,8 @@ export default class CreateRecipe extends Component {
                 required
                 id="imageUrl"
                 name="imageUrl"
-                value={this.props.imageUrl}
+                value={this.props.progress === 100 ? this.props.image.name : this.props.imageUrl}
+                disabled={this.props.progress === 100}
                 label="Image URL"
                 fullWidth
               />

--- a/src/components/CreateRecipe.js
+++ b/src/components/CreateRecipe.js
@@ -112,7 +112,7 @@ export default class CreateRecipe extends Component {
               >
                 {this.props.progress === 100 ? "Sucess!" : "Upload Image"}
 
-                <input type="file" style={{ display: "none" }} />
+                <input type="file" style={{ display: "none" }} accept="image/*" />
               </Button>
             </Grid>
             {this.props.progress !== 0 && (

--- a/src/components/CreateRecipe.js
+++ b/src/components/CreateRecipe.js
@@ -12,6 +12,7 @@ import InputLabel from "@material-ui/core/InputLabel";
 import Select from "@material-ui/core/Select";
 import Paper from "@material-ui/core/Paper";
 import FormLabel from "@material-ui/core/FormLabel";
+import LinearProgress from "@material-ui/core/LinearProgress";
 import { GlobalCss } from "../materialUI/styles";
 
 export default class CreateRecipe extends Component {
@@ -75,7 +76,7 @@ export default class CreateRecipe extends Component {
               />
             </Grid>
             {/* Description */}
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12}>
               <TextField
                 required
                 label="Short description"
@@ -87,7 +88,7 @@ export default class CreateRecipe extends Component {
               />
             </Grid>
             {/* Image URL */}
-            <Grid item xs={12} sm={6}>
+            <Grid item xs={12} sm={7}>
               <TextField
                 required
                 id="imageUrl"
@@ -97,6 +98,27 @@ export default class CreateRecipe extends Component {
                 fullWidth
               />
             </Grid>
+            <Grid item xs={2} className="d-flex align-self-end justify-content-center">
+              <Typography variant="body1">OR</Typography>
+            </Grid>
+            <Grid item xs={5} sm={3} className="d-flex align-self-end justify-content-end">
+              <Button
+                variant="contained"
+                component="label"
+                onChange={this.props.handleUpload}
+                color={this.props.progress === 100 ? "primary" : "default"}
+                style={{ fontSize: "12px", width: "100%" }}
+              >
+                {this.props.progress === 100 ? "Sucess!" : "Upload Image"}
+
+                <input type="file" style={{ display: "none" }} />
+              </Button>
+            </Grid>
+            {this.props.progress !== 0 && (
+              <Grid item xs={12}>
+                <LinearProgress variant="determinate" value={this.props.progress} />
+              </Grid>
+            )}
             {/* Ingredients  Title*/}
             <Grid item xs={12}>
               <Typography variant="h6" id="difficulty-slider" display="block">

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -73,6 +73,7 @@ export default class RecipeForm extends Component {
             difficulty={this.state.difficulty}
             description={this.state.description}
             ingredients={this.state.ingredients}
+            image={this.state.image}
             imageUrl={this.state.imageUrl}
             duration={this.state.duration}
             servings={this.state.servings}

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -16,6 +16,9 @@ import { navigate } from "@reach/router";
 
 import firebase from "./../firebase/config";
 import "firebase/firestore";
+import "firebase/storage";
+
+const storage = firebase.storage();
 var db = firebase.firestore();
 
 const steps = ["Create Recipe", "Review your Recipe"];
@@ -29,6 +32,8 @@ export default class RecipeForm extends Component {
       title: "",
       description: "",
       imageUrl: "",
+      image: null,
+      progress: 0,
       difficulty: "Easy",
       duration: 10,
       isPrivate: false,
@@ -43,6 +48,7 @@ export default class RecipeForm extends Component {
     this.handleNewRecipeSubmit = this.handleNewRecipeSubmit.bind(this);
     this.handleCheckbox = this.handleCheckbox.bind(this);
     this.addIngredient = this.addIngredient.bind(this);
+    this.handleUpload = this.handleUpload.bind(this);
     this.handleSlider = this.handleSlider.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.addStep = this.addStep.bind(this);
@@ -58,9 +64,11 @@ export default class RecipeForm extends Component {
             handleSlider={this.handleSlider}
             addIngredient={this.addIngredient}
             handleCheckbox={this.handleCheckbox}
+            handleUpload={this.handleUpload}
             title={this.state.title}
             flags={this.state.flags}
             steps={this.state.steps}
+            progress={this.state.progress}
             user_name={this.state.user_name}
             difficulty={this.state.difficulty}
             description={this.state.description}
@@ -91,6 +99,39 @@ export default class RecipeForm extends Component {
         throw new Error("Unknown step");
     }
   }
+
+  handleUpload = e => {
+    if (e.target.files[0] && e.target.files[0] !== this.state.image) {
+      const image = e.target.files[0];
+      this.setState(
+        () => ({ image }),
+        () => {
+          const { image } = this.state;
+          const uploadTask = storage.ref(`images/${image.name}`).put(image);
+          uploadTask.on(
+            "state_changed",
+            snapshot => {
+              const progress = Math.round((snapshot.bytesTransferred / snapshot.totalBytes) * 100);
+              this.setState({ progress });
+            },
+            error => {
+              console.log(error);
+            },
+            () => {
+              storage
+                .ref("images")
+                .child(image.name)
+                .getDownloadURL()
+                .then(imageUrl => {
+                  console.log(imageUrl);
+                  this.setState({ imageUrl });
+                });
+            }
+          );
+        }
+      );
+    }
+  };
 
   validate(title, description, imageUrl, ingredients, steps) {
     let validObj = {

--- a/src/components/RecipeForm.js
+++ b/src/components/RecipeForm.js
@@ -124,7 +124,6 @@ export default class RecipeForm extends Component {
                 .child(image.name)
                 .getDownloadURL()
                 .then(imageUrl => {
-                  console.log(imageUrl);
                   this.setState({ imageUrl });
                 });
             }


### PR DESCRIPTION
# Description
Bei Erstellung eines Rezepts kann jetzt auch ein Bild hochgeladen werden.

## Funktionsweise
Diese Funktion macht gebraucht von Firebase Storage (nicht Firestore).
Firebase Storage ist darauf ausgelegt Dateien zu speichern, wohingegen Firestore nur Dokumente bis zu 1MB erlaubt.
Sobald der Nutzer ein Bild hochlädt wird dieses in Firebase Storage gespeichert und ein Link erstellt der in unserem `imageUrl`-state gespeichert wird.


## Limitierungen
Dadurch, dass das Hochladen und die ImageUrl auf denselben State zugreifen, gibt es einige nicht gravierende Limitierungen.

* Sobald der Nutzer ein Bild hochgeladen hat, kann er keine Image-Url mehr angeben. (Aber ein anderes Bild hochladen funktioniert)
   * Diese Maßnahme muss gemacht werden, weil der Nutzer sonst den TextInput modifizieren könnte, was dazu führt, dass das hochgeladene Bild verloren geht.
* Wenn der Nutzer, sich umentscheidet ein anderes Bild hochzuladen, wird für kurze Zeit die Bild-URL des vorherigen Bilds im TextInput sichtbar. Das ist nur ein visueller Bug, der zu aufwendig ist um ihn kurz zu fixen, weil hiermit die ganze ImageUrl-Struktur umgebaut werden muss.