### PR TITLE
Fix font-size of recipe-title on smaller viewports ↔

### DIFF
--- a/src/sass/components/_Recipe.scss
+++ b/src/sass/components/_Recipe.scss
@@ -34,8 +34,15 @@
 
 .recipe-title {
     font-family: $recipe-title;
-    font-size: 4.5rem;
     font-weight: 400;
+}
+
+@media (min-width:576px) {
+    .recipe-title {
+        font-family: $recipe-title;
+        font-size: 4.5rem;
+        font-weight: 400;
+    }
 }
 
 .description {

--- a/src/sass/components/_Recipe.scss
+++ b/src/sass/components/_Recipe.scss
@@ -39,9 +39,7 @@
 
 @media (min-width:576px) {
     .recipe-title {
-        font-family: $recipe-title;
         font-size: 4.5rem;
-        font-weight: 400;
     }
 }
 


### PR DESCRIPTION
# Description
Die Schrift wird auf kleineren Ansichten verkleinert, damit sich die Seite nicht nach rechts erweitert. 